### PR TITLE
Remove all usages of match

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "memes",
       "version": "1.0.0",
       "license": "ISC",
-      "dependencies": {
-        "ts-pattern": "^4.0.1"
-      },
       "devDependencies": {
         "@types/screeps-arena": "screepers/typed-screeps-arena#develop",
         "typedoc": "^0.22.15",
@@ -157,10 +154,6 @@
         "vscode-oniguruma": "^1.6.1",
         "vscode-textmate": "5.2.0"
       }
-    },
-    "node_modules/ts-pattern": {
-      "version": "4.0.1",
-      "license": "MIT"
     },
     "node_modules/typedoc": {
       "version": "0.22.15",
@@ -315,9 +308,6 @@
         "vscode-oniguruma": "^1.6.1",
         "vscode-textmate": "5.2.0"
       }
-    },
-    "ts-pattern": {
-      "version": "4.0.1"
     },
     "typedoc": {
       "version": "0.22.15",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,5 @@
     "@types/screeps-arena": "screepers/typed-screeps-arena#develop",
     "typedoc": "^0.22.15",
     "typescript": "^4.6.3"
-  },
-  "dependencies": {
-    "ts-pattern": "^4.0.1"
   }
 }

--- a/src/roles/basecreep.ts
+++ b/src/roles/basecreep.ts
@@ -27,7 +27,6 @@ import {
     StructureTower,
 } from "game/prototypes";
 import { getRange, getTicks } from "game/utils";
-import { match } from "ts-pattern";
 import { World } from "../world";
 
 interface possibleDamage {
@@ -145,21 +144,14 @@ class BaseCreep extends Creep {
     }
 
     public get targets(): BaseCreep[] {
-        let res: BaseCreep[] = [];
-        match(this.loadout)
-            .with(
-                Loadout.BRAWLER,
-                () => (res = this.findInRange(World.enemies, 1))
-            )
-            .with(
-                Loadout.ARCHER,
-                () => (res = this.findInRange(World.enemies, 3))
-            )
-            .with(
-                Loadout.HEALER,
-                () => (res = this.findInRange(World.allies, 3))
-            );
-        return res;
+        switch (this.loadout) {
+            case Loadout.BRAWLER:
+                return this.findInRange(World.enemies, 1);
+            case Loadout.ARCHER:
+                return this.findInRange(World.enemies, 3);
+            case Loadout.HEALER:
+                return this.findInRange(World.allies, 3);
+        }
     }
 
     public get primitiveCreep(): Creep {

--- a/src/roles/defender.ts
+++ b/src/roles/defender.ts
@@ -1,5 +1,4 @@
 import { Creep } from "game/prototypes";
-import { match, P } from "ts-pattern";
 import { World } from "../world";
 import { BaseCreep, Loadout } from "./basecreep";
 
@@ -68,10 +67,14 @@ class Defender extends BaseCreep {
     }
 
     public run() {
-        match(this.loadout)
-            .with(Loadout.BRAWLER, () => this.runBrawler())
-            .with(Loadout.HEALER, () => this.runHealer())
-            .with(Loadout.ARCHER, () => this.runArcher());
+        switch (this.loadout) {
+            case Loadout.BRAWLER:
+                this.runBrawler();
+            case Loadout.HEALER:
+                this.runHealer();
+            case Loadout.ARCHER:
+                this.runArcher();
+        }
     }
 }
 


### PR DESCRIPTION
External modules seem to be (unsurprisingly) not supported by screeps